### PR TITLE
Allow proper handling of quoted aliases

### DIFF
--- a/ct
+++ b/ct
@@ -254,7 +254,7 @@ while [ "$curr" != "/" ]; do
 		else
 			cd "$callDir" > /dev/null
 			log "${green}We will run '$@' in '$(pwd)'";
-			eval "\$$@";
+            eval "eval \"\$$@\"";
 		fi
 	fi
     # Go back to the base directory, null out output if CDPATH exists


### PR DESCRIPTION
When using an alias like 
    `a='echo "first           second"'` 
quoting was not properly respected and the lots of spaces were converted to a single one
