### PR TITLE
fix(#19): use sh -c to invoke aliased command

### DIFF
--- a/.ctproject
+++ b/.ctproject
@@ -1,4 +1,6 @@
 run="cargo run help" #run the binary
 build="cargo build --release" #build the release binary
 help=cat .ctproject
-dummy=echo toto
+dummy=echo "toto is dumb"
+ragdoll=echo 'tata is a ragdoll'
+combine=echo "toto is dumb" && echo "tata is a ragdoll" # no recursive ct invoke for this test sentence

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -37,9 +37,14 @@ impl RunCommand{
     }
 
     pub fn run(&self, ct_file: &CTFile){
-        println!(">> {:?}, {:?}", &self.command, &self.args);
-        let s = Command::new(&self.command)
-            .args(&self.args)
+//        println!(">> {:?}, {:?}", &self.command, &self.args);
+        let mut sh_sub_command = Vec::new();
+        sh_sub_command.push(self.command.to_string());
+        sh_sub_command.push(String::from(" "));
+        sh_sub_command.push(self.args.join(" ")); // no need to escape "', it is properly handled
+        let s = Command::new("sh")
+            .arg("-c")
+            .arg(sh_sub_command.join(""))
             .current_dir(ct_file.path.clone())
             .spawn().unwrap();
         //result printed to stdout / stderr as expected as io are shared


### PR DESCRIPTION
As aliased command could consist in &&, ||, & or other terminal specific combination.
I did not chose to rewrite a (buggy) parser and prefer to rely on `sh -c "command"` style invoke.