### PR TITLE
fix(#30): ensure lsof is available for ports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,12 @@ pub fn init_project(){
 
 
 pub fn start_port_listening() {
-    println!("👂 Started ports web server at http://localhost:1500, CTRL+C to exit...");
-    start_hyper();
+    if CTPorts::available() {
+        println!("👂 Started ports web server at http://localhost:1500, CTRL+C to exit...");
+        start_hyper();
+    }else{
+        println!("🙉 Unable to start port server, please make sure lsof is available");
+    }
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use std::env;
 use std::string::String;
 use linked_hash_map::LinkedHashMap;
 use ct::log::debug_log;
+use ct::ports::CTPorts;
 
 
 fn main() -> Result<(), String> {
@@ -33,9 +34,12 @@ fn main() -> Result<(), String> {
 
 
 fn help(ct_file: &Option<CTFile>) -> String{
+    let ports_available = CTPorts::available();
     let mut help : Vec<String> = Vec::new();
     help.push("Default commands :".green().to_string());
-    help.push(format!("\t• {} runs a server on http://localhost:1500 to see other used ports 👂", "ports".blue()));
+    if ports_available {
+        help.push(format!("\t• {} runs a server on http://localhost:1500 to see other used ports 👂", "ports".blue()));
+    }
     help.push(format!("\t• {} provide manual from content {{name}} of README.md 📖", "man {name}".blue()));
     help.push(String::from(""));
     if let Some(file) = ct_file {

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -7,6 +7,7 @@ use self::itertools::Itertools;
 use self::regex::Regex;
 use std::process::Command;
 use std::process::Output;
+use std::process::Stdio;
 
 
 #[derive(Serialize, Deserialize,Debug)]
@@ -18,6 +19,18 @@ pub struct CTPorts{
 }
 
 impl CTPorts{
+
+    //result is not cached but it should not be invoked more than once per ct call, so this is not a big deal
+    pub fn available() -> bool {
+        match Command::new("lsof")
+                      .arg("-v")
+                      .stdout(Stdio::null())
+                      .stderr(Stdio::null())
+                      .spawn(){
+            Ok(_) => true,
+            Err(_) => false
+        }
+    }
 
     pub fn all() -> Result<Vec<CTPorts>, ()>{
         let lsof_output = CTPorts::run_lsof();


### PR DESCRIPTION
Ports subcommand need lsof to run, ensure it is available when printing help or running command.