### PR TITLE
fix(#28): Disable coloring on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ use ct::ports::CTPorts;
 
 fn main() -> Result<(), String> {
     show_banner();
+    if cfg!(windows) {
+        // disable colored text output on Windows as the Windows terminals do not support it yet
+        colored::control::set_override(false);
+    }
     let app_args: Vec<String> = env::args().collect();
     debug_log(|| String::from("Read ct file"));
     let ct_file = CTFile::get_content().ok();


### PR DESCRIPTION
Windows does not support coloring (it should on powershell starting with #14931, but did not manage to get it working).
In the meantime, disable coloring for windows build to provide better readability.

Fixes #28 