### PR TITLE
feat(#13): implemented `man --help`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,12 @@ pub fn start_port_listening() {
 }
 
 
-pub fn show_man(man_entry: Option<&str>, ct_file: Option<CTFile>) {
+pub fn show_man(man_entry: Option<&str>, help: bool, ct_file: Option<CTFile>) {
     if let Some(ct_file) = ct_file {
+        if help{
+            CTMan::help(&ct_file);
+            return
+        }
         if let Some(ct_man) = CTMan::all(&ct_file) {
             if man_entry.is_some() {
                 if let Some(man) = ct_man.get(man_entry.unwrap()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ fn help(ct_file: &Option<CTFile>) -> String{
 fn run(ct_file: Option<CTFile>, config: Option<Config>) -> Result<(), String>{
     let args: Vec<App> = vec![SubCommand::with_name("man")
                                   .about("provide manual from content {{name}} of README.md 📖")
+                                  .arg(Arg::with_name("help").short("h").long("help").help("Lists available topics"))
                                   .arg(Arg::with_name("name").multiple(true).help("extract content")),
                               SubCommand::with_name("ports")
                                   .about("runs a server on http://localhost:1500 to see other used ports 👂")];
@@ -90,7 +91,7 @@ fn run(ct_file: Option<CTFile>, config: Option<Config>) -> Result<(), String>{
         if args.iter().map(|a| a.get_name().to_string()).filter(|c| c == &command.name).count() > 0{
             match command.name.as_ref() {
                 "ports" => start_port_listening(),
-                "man" => show_man(command.matches.value_of("name"), ct_file),
+                "man" => show_man(command.matches.value_of("name"), command.matches.is_present("help"), ct_file),
                 _ => debug_log(|| String::from("")),
             }
 

--- a/src/man.rs
+++ b/src/man.rs
@@ -30,6 +30,14 @@ impl CTMan{
         out
     }
 
+    pub fn help(ct_file: &CTFile){
+        if let Some(readme_content )= CTMan::all(ct_file){
+            println!("{}", "Found the following manual topics in README.md".blue());
+            readme_content.iter().map(|v| v.1)
+                .for_each(|v| println!("{}", v.title));
+        }
+    }
+
     pub fn print(&self){
         println!("{}", self.title.blue());
         println!("{}", self.content);


### PR DESCRIPTION
Added `man --help` or `man -h` to print out available help topics

Fixes #13 